### PR TITLE
Fix initial production build setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "narraleaf-react",
   "version": "0.8.7",
   "description": "A React visual novel player framework",
+  "type": "module",
   "main": "./dist/main.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/main.js",
-      "require": "./dist/main.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/main.js"
     }
   },
   "scripts": {

--- a/src/game/player/lib/ErrorFallback.tsx
+++ b/src/game/player/lib/ErrorFallback.tsx
@@ -1,7 +1,9 @@
 import React, {ErrorInfo} from "react";
 import {useGame} from "@player/provider/game-state";
 
-export default function ErrorFallback({error, errorInfo}: { error: Error, errorInfo: ErrorInfo }) {
+type ErrorFallbackInfo = ErrorInfo & { digest?: string };
+
+export default function ErrorFallback({error, errorInfo}: { error: Error, errorInfo: ErrorFallbackInfo }) {
     const game = useGame();
 
     if (game.config.app.debug) {


### PR DESCRIPTION
### Motivation
- Eliminate build-time warnings caused by Node module type ambiguity so the esbuild/tsc pipeline runs without module-type warnings. 
- Allow the player error fallback to display an optional error `digest` (used by some error reporters) while remaining compatible with React's `ErrorInfo` type.

### Description
- Add `"type": "module"` to `package.json` to mark the package as ESM and avoid Node/ESM parsing warnings. 
- Reorder the `exports["."]` fields so the `types` condition is available to TypeScript consumers before `import`/`require`. 
- Introduce `type ErrorFallbackInfo = ErrorInfo & { digest?: string }` and update `ErrorFallback` to accept `errorInfo: ErrorFallbackInfo` so the optional `digest` can be shown in the debug UI without breaking TypeScript.

### Testing
- Ran `yarn install` which completed successfully. 
- Ran `yarn build` which completed successfully and produced `dist/` artifacts. 
- Ran `yarn lint` which failed due to repository-wide `linebreak-style` (CRLF) expectations conflicting with LF line endings, producing many lint errors unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a303aff6d748332a51ef89797fc050c)